### PR TITLE
Rounding options

### DIFF
--- a/elePyant/core.py
+++ b/elePyant/core.py
@@ -62,6 +62,8 @@ def round_array(x, nsd=None, dsd=None):
 
     Args:
         x (numpy.ndarray)
+        nsd (int)
+        dsd (int)
 
     """
     if nsd and dsd:
@@ -77,9 +79,8 @@ def round_array(x, nsd=None, dsd=None):
         raise Exception("Must set either `nsd` or `dsd`.")
 
 
-
 def round_dataarray(da, *, keep_attrs=True, inplace=False, **kwargs):
-    """Round an xarray.DataArray
+    """Round and return an xarray.DataArray.
 
     Args:
         da (xarray.DataArray): Data array to be rounded
@@ -92,8 +93,9 @@ def round_dataarray(da, *, keep_attrs=True, inplace=False, **kwargs):
         kwargs : passed on to ``round_array``
 
     """
-    # optionally inplace?
     assert isinstance(da, xr.DataArray)
+
+    da_rounded = da if inplace else da.copy()
 
     da_rounded[:] = round_array(da.values, **kwargs)
 
@@ -113,7 +115,7 @@ def compress_dataarray(da, out_filename, decimal_places):
             variable to.
 
     Notes:
-        - No rounding is applied to coordinates?
+        - No rounding is applied to coordinates
     """
 
     assert isinstance(da, xr.DataArray)

--- a/elePyant/core.py
+++ b/elePyant/core.py
@@ -46,7 +46,7 @@ def _round_nsd_base10(x, nsd):
     """
     where_zero = x == 0  # avoid taking log10 of 0
     tens = np.ones_like(x)
-    tens[~where_zero] = 10 ** np.ceil(np.log10(np.abs(x[~where_zero])))
+    tens[~where_zero] = 10 ** np.ceil(np.log10(np.abs(x[~where_zero].astype(np.float64))))
     # note: could instead pass `where=where_zero` to np.abs or np.log etc.
     
     # "true normalized" significand

--- a/elePyant/core.py
+++ b/elePyant/core.py
@@ -44,9 +44,9 @@ def _round_nsd_base10(x, nsd):
     numpy.array
         rounded array
     """
-    where_zero = x == 0  # avoid taking log10 of 0
+    take_log = (x != 0) & np.isfinite(x)  # avoid taking log10 of 0 and inf/inf
     tens = np.ones_like(x)
-    tens[~where_zero] = 10 ** np.ceil(np.log10(np.abs(x[~where_zero].astype(np.float64))))
+    tens[take_log] = 10 ** np.ceil(np.log10(np.abs(x[take_log].astype(np.float64))))
     # note: could instead pass `where=where_zero` to np.abs or np.log etc.
     
     # "true normalized" significand

--- a/elePyant/test/test_core.py
+++ b/elePyant/test/test_core.py
@@ -4,6 +4,7 @@ Module containing tests for the elePyant.core module.
 """
 import os.path as osp
 import pytest
+import numpy as np
 import xarray as xr
 import elePyant.test as ept
 import elePyant as ep
@@ -58,3 +59,18 @@ class TestnetCDFFuncs:
         # Compress using dict decimal_places
         dp_dict = {'UVEL': 2, 'VVEL': 2, 'WVEL': 6}
         ep.compress_netcdf(ds_path, ds_out_path, dp_dict)
+
+
+@pytest.mark.parametrize(
+    ("x", "nsd", "expected"),
+    [
+        (
+            np.r_[1.114, 1.115, -1.114, 1.114e-30, 1.114e+30, 0, np.inf],
+            3,
+            np.r_[1.11, 1.12, -1.11, 1.11e-30, 1.11e+30, 0.0, np.inf]
+        ),
+    ]
+)
+def test_round_nsd_base10(x, nsd, expected):
+    rounded = ep.core._round_nsd_base10(x, nsd)
+    assert np.alltrue(rounded == expected)


### PR DESCRIPTION
This adds a new rounding method that aims to preserve significant figures ("sig figs") in base 10 (as opposed to decimal places), and a new function `round_dataarray` that can use either rounding method.

I also implemented the rounding in binary (https://github.com/fraserwg/elePyant/issues/1) following https://github.com/fraserwg/elePyant/issues/1#issuecomment-658438978, but wanted to see if/how you wanted to handle options in the `compress_` functions first before I include that. My thought was that they could call `round_dataarray`, but arguments would need to be changed.